### PR TITLE
make tm-cleanup.sh work on the zsh 5.0.8 in El Capitan

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ just wish to use this software have to download a release tarball.  Release
 tarball are attached to each release.  The [latest] release of this package can
 always be found using the [latest] tag.
 
-[latest]: https://github.com/emcrisostomo/Time-Machine-Cleanup/releases/latest].
+[latest]: https://github.com/emcrisostomo/Time-Machine-Cleanup/releases/latest
 
 Once a release tarball has been downloaded and uncompressed, this package can be
 installed using the following commands:

--- a/src/tm-cleanup.sh.in
+++ b/src/tm-cleanup.sh.in
@@ -43,10 +43,14 @@ typeset -i EXECUTION_MODE=${MODE_UNKNOWN}
 typeset -i ARGS_PROCESSED=0
 typeset -a TM_BACKUPS
 typeset -i TM_BACKUPS_LOADED=0
-typeset -a TM_DIALOG_OPTS=( --backtitle "Time Machine Cleanup" )
-typeset -a TM_DIALOG_CMD=( dialog ${TM_DIALOG_OPTS} )
-typeset -a TM_OPERATIONS=( D "Delete backups" E "Exit" )
-typeset -A TM_OPERATION_NAMES=( D "Delete backups" E "Exit" )
+typeset -a TM_DIALOG_OPTS
+TM_DIALOG_OPTS=( --backtitle "Time Machine Cleanup" )
+typeset -a TM_DIALOG_CMD
+TM_DIALOG_CMD=( dialog ${TM_DIALOG_OPTS} )
+typeset -a TM_OPERATIONS
+TM_OPERATIONS=( D "Delete backups" E "Exit" )
+typeset -A TM_OPERATION_NAMES
+TM_OPERATION_NAMES=( D "Delete backups" E "Exit" )
 
 typeset -ri DIALOG_OK=0
 typeset -ri DIALOG_CANCEL=1
@@ -300,7 +304,8 @@ tm_show_last_error()
 
 tm_delete_backups()
 {
-  local -a backup_idx_to_delete=( ${=*} )
+  local -a
+  backup_idx_to_delete=( ${=*} )
 
   if (( ${#backup_idx_to_delete} == 0 ))
   then


### PR DESCRIPTION
In zsh 5.0.8 arrays cannot be declared and assigned in the same line. Apple has yet to discontinue support for El Capitan, containing zsh 5.0.8.

for clarification, here is the problem on El Capitan:

% echo $ZSH_VERSION
5.0.8
% typeset -a TM_DIALOG_OPTS=( --backtitle "Time Machine Cleanup" )
zsh: unknown file attribute:

zsh 5.2 from OS X 10.12 Sierra passes this test.